### PR TITLE
fix: order of import, improve formatting

### DIFF
--- a/src/GridsterOptions.ts
+++ b/src/GridsterOptions.ts
@@ -1,6 +1,6 @@
 import { Observable } from 'rxjs/Observable';
 
-import {IGridsterOptions} from './IGridsterOptions';
+import { IGridsterOptions } from './IGridsterOptions';
 
 export class GridsterOptions {
     direction: string;

--- a/src/GridsterOptions.ts
+++ b/src/GridsterOptions.ts
@@ -1,5 +1,6 @@
-import {IGridsterOptions} from './IGridsterOptions';
 import { Observable } from 'rxjs/Observable';
+
+import {IGridsterOptions} from './IGridsterOptions';
 
 export class GridsterOptions {
     direction: string;

--- a/src/gridList/GridListItem.ts
+++ b/src/gridList/GridListItem.ts
@@ -1,6 +1,6 @@
-import {GridsterItemComponent} from '../gridster-item/gridster-item.component';
-import {GridsterItemPrototypeDirective} from '../gridster-prototype/gridster-item-prototype.directive';
-import {GridsterService} from '../gridster.service';
+import { GridsterItemComponent } from '../gridster-item/gridster-item.component';
+import { GridsterItemPrototypeDirective } from '../gridster-prototype/gridster-item-prototype.directive';
+import { GridsterService } from '../gridster.service';
 
 export class GridListItem {
     static BREAKPOINTS: Array<string> = ['sm', 'md', 'lg', 'xl'];

--- a/src/gridList/gridList.ts
+++ b/src/gridList/gridList.ts
@@ -1,7 +1,8 @@
 import { EventEmitter } from '@angular/core';
-import {GridListItem} from './GridListItem';
-import {IGridsterOptions} from '../IGridsterOptions';
-import {GridsterOptions} from '../GridsterOptions';
+
+import { GridListItem } from './GridListItem';
+import { IGridsterOptions } from '../IGridsterOptions';
+import { GridsterOptions } from '../GridsterOptions';
 
 const GridCol = function (lanes) {
     for (let i = 0; i < lanes; i++) {

--- a/src/gridster-prototype/gridster-item-prototype.directive.ts
+++ b/src/gridster-prototype/gridster-item-prototype.directive.ts
@@ -10,11 +10,11 @@ import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/takeUntil';
 
 import { GridsterPrototypeService } from './gridster-prototype.service';
-import {GridListItem} from '../gridList/GridListItem';
-import {GridsterService} from '../gridster.service';
-import {DraggableEvent} from '../utils/DraggableEvent';
-import {Draggable} from '../utils/draggable';
-import {utils} from '../utils/utils';
+import { GridListItem } from '../gridList/GridListItem';
+import { GridsterService } from '../gridster.service';
+import { DraggableEvent } from '../utils/DraggableEvent';
+import { Draggable } from '../utils/draggable';
+import { utils } from '../utils/utils';
 
 @Directive({
     selector: '[gridsterItemPrototype]'

--- a/src/gridster-prototype/gridster-prototype.service.ts
+++ b/src/gridster-prototype/gridster-prototype.service.ts
@@ -9,8 +9,8 @@ import 'rxjs/add/operator/scan';
 import 'rxjs/add/operator/filter';
 
 import { GridsterService } from '../gridster.service';
-import {GridsterItemPrototypeDirective} from './gridster-item-prototype.directive';
-import {GridListItem} from '../gridList/GridListItem';
+import { GridsterItemPrototypeDirective } from './gridster-item-prototype.directive';
+import { GridListItem } from '../gridList/GridListItem';
 
 @Injectable()
 export class GridsterPrototypeService {

--- a/src/gridster.component.ts
+++ b/src/gridster.component.ts
@@ -8,12 +8,12 @@ import 'rxjs/add/operator/takeUntil';
 import 'rxjs/add/observable/fromEvent';
 
 import { GridsterService } from './gridster.service';
-import {IGridsterOptions} from './IGridsterOptions';
-import {IGridsterDraggableOptions} from './IGridsterDraggableOptions';
-import {GridsterPrototypeService} from './gridster-prototype/gridster-prototype.service';
-import {GridsterItemPrototypeDirective} from './gridster-prototype/gridster-item-prototype.directive';
-import {GridListItem} from './gridList/GridListItem';
-import {GridsterOptions} from './GridsterOptions';
+import { IGridsterOptions } from './IGridsterOptions';
+import { IGridsterDraggableOptions } from './IGridsterDraggableOptions';
+import { GridsterPrototypeService } from './gridster-prototype/gridster-prototype.service';
+import { GridsterItemPrototypeDirective } from './gridster-prototype/gridster-item-prototype.directive';
+import { GridListItem } from './gridList/GridListItem';
+import { GridsterOptions } from './GridsterOptions';
 
 
 @Component({

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
-export {GridsterModule} from './gridster.module';
-export {GridsterComponent} from './gridster.component';
-export {GridsterItemComponent} from './gridster-item/gridster-item.component';
-export {GridsterItemPrototypeDirective} from './gridster-prototype/gridster-item-prototype.directive';
-export {IGridsterOptions} from './IGridsterOptions';
-export {IGridsterDraggableOptions} from './IGridsterDraggableOptions';
-export {GridsterOptions} from './GridsterOptions';
+export { GridsterModule } from './gridster.module';
+export { GridsterComponent } from './gridster.component';
+export { GridsterItemComponent } from './gridster-item/gridster-item.component';
+export { GridsterItemPrototypeDirective } from './gridster-prototype/gridster-item-prototype.directive';
+export { IGridsterOptions } from './IGridsterOptions';
+export { IGridsterDraggableOptions } from './IGridsterDraggableOptions';
+export { GridsterOptions } from './GridsterOptions';

--- a/src/utils/draggable.ts
+++ b/src/utils/draggable.ts
@@ -6,8 +6,8 @@ import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/merge';
 import 'rxjs/add/operator/map';
 
-import {DraggableEvent} from './DraggableEvent';
-import {utils} from './utils';
+import { DraggableEvent } from './DraggableEvent';
+import { utils } from './utils';
 
 export class Draggable {
     element: Element;


### PR DESCRIPTION
- implemented leaving one empty line between third party
imports and application imports. This is according to [angular's style guideline](https://angular.io/guide/styleguide#import-line-spacing)