### PR TITLE
remove unnecessary import of entirety of Rxjs

### DIFF
--- a/demo/src/app/gridster/gridster-item/gridster-item.component.ts
+++ b/demo/src/app/gridster/gridster-item/gridster-item.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, ElementRef, Inject, Host, Input, Output, ViewChild,
     EventEmitter, SimpleChanges, OnChanges, OnDestroy, HostBinding, HostListener,
     ChangeDetectionStrategy, AfterViewInit, NgZone } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/Rx';
 import { ISubscription, Subscription } from 'rxjs/Subscription';
 
 import { GridsterService } from '../gridster.service';

--- a/src/gridster-item/gridster-item.component.ts
+++ b/src/gridster-item/gridster-item.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit, ElementRef, Inject, Host, Input, Output, ViewChild,
     EventEmitter, SimpleChanges, OnChanges, OnDestroy, HostBinding, HostListener,
     ChangeDetectionStrategy, AfterViewInit, NgZone } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import 'rxjs/Rx';
 import { ISubscription, Subscription } from 'rxjs/Subscription';
 
 import { GridsterService } from '../gridster.service';


### PR DESCRIPTION
Removed the rxjs/Rx imports to prevent importing the entirety of Rxjs to reduce vendor bundle size when angular2gridster is being imported into a project.