### PR TITLE
TypeError: Cannot read property scrollTop of null, hot fix Added @Output bindings to gridster.item.components (start) and (end)

### DIFF
--- a/demo/src/app/gridster/gridster-item/gridster-item.component.ts
+++ b/demo/src/app/gridster/gridster-item/gridster-item.component.ts
@@ -166,6 +166,8 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
     @Output() hChange = new EventEmitter<number>();
 
     @Output() change = new EventEmitter<any>();
+    @Output() start = new EventEmitter<any>();
+    @Output() end = new EventEmitter<any>();
 
     @Input() dragAndDrop = true;
     @Input() resizable = true;
@@ -361,6 +363,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                             cursorToElementPosition = event.getRelativeCoordinates(this.$element);
 
                             this.gridster.onResizeStart(this.item);
+                            this.onStart('resize');
                         });
                     });
 
@@ -390,6 +393,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                             this.isResizing = false;
 
                             this.gridster.onResizeStop(this.item);
+                            this.onEnd('resize');
                         });
                     });
 
@@ -426,6 +430,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                     this.zone.run(() => {
                         this.gridster.onStart(this.item);
                         this.isDragging = true;
+                        this.onStart('drag');
 
                         cursorToElementPosition = event.getRelativeCoordinates(this.$element);
                     });
@@ -449,6 +454,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                         this.gridster.onStop(this.item);
                         this.gridster.render();
                         this.isDragging = false;
+                        this.onEnd('drag');
                     });
                 });
 
@@ -519,6 +525,14 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
             scrollLeft: scrollData.scrollLeft,
             scrollTop: scrollData.scrollTop
         };
+    }
+
+    private onEnd(actionType: string): void {
+        this.end.emit({action: actionType, item: this.item});
+    }
+
+    private onStart(actionType: string): void {
+        this.start.emit({action: actionType, item: this.item});
     }
 
     /**

--- a/demo/src/app/gridster/gridster.component.ts
+++ b/demo/src/app/gridster/gridster.component.ts
@@ -212,7 +212,7 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
 
     private getScrollPositionFromParents(element: Element, data = {scrollTop: 0, scrollLeft: 0}): {scrollTop: number, scrollLeft: number} {
 
-        if (element.parentElement !== document.body) {
+        if (element.parentElement && element.parentElement !== document.body) {
             data.scrollTop += element.parentElement.scrollTop;
             data.scrollLeft += element.parentElement.scrollLeft;
 

--- a/src/gridster-item/gridster-item.component.ts
+++ b/src/gridster-item/gridster-item.component.ts
@@ -166,6 +166,8 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
     @Output() hChange = new EventEmitter<number>();
 
     @Output() change = new EventEmitter<any>();
+    @Output() start = new EventEmitter<any>();
+    @Output() end = new EventEmitter<any>();
 
     @Input() dragAndDrop = true;
     @Input() resizable = true;
@@ -361,6 +363,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                             cursorToElementPosition = event.getRelativeCoordinates(this.$element);
 
                             this.gridster.onResizeStart(this.item);
+                            this.onStart();
                         });
                     });
 
@@ -390,6 +393,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                             this.isResizing = false;
 
                             this.gridster.onResizeStop(this.item);
+                            this.onEnd();
                         });
                     });
 
@@ -426,6 +430,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                     this.zone.run(() => {
                         this.gridster.onStart(this.item);
                         this.isDragging = true;
+                        this.onStart();
 
                         cursorToElementPosition = event.getRelativeCoordinates(this.$element);
                     });
@@ -449,6 +454,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                         this.gridster.onStop(this.item);
                         this.gridster.render();
                         this.isDragging = false;
+                        this.onEnd();
                     });
                 });
 
@@ -519,6 +525,14 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
             scrollLeft: scrollData.scrollLeft,
             scrollTop: scrollData.scrollTop
         };
+    }
+
+    private onEnd(): void {
+        this.end.emit({item: this.item});
+    }
+
+    private onStart(): void {
+        this.start.emit({item: this.item});
     }
 
     /**

--- a/src/gridster-item/gridster-item.component.ts
+++ b/src/gridster-item/gridster-item.component.ts
@@ -363,7 +363,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                             cursorToElementPosition = event.getRelativeCoordinates(this.$element);
 
                             this.gridster.onResizeStart(this.item);
-                            this.onStart();
+                            this.onStart('resize');
                         });
                     });
 
@@ -393,7 +393,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                             this.isResizing = false;
 
                             this.gridster.onResizeStop(this.item);
-                            this.onEnd();
+                            this.onEnd('resize');
                         });
                     });
 
@@ -430,7 +430,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                     this.zone.run(() => {
                         this.gridster.onStart(this.item);
                         this.isDragging = true;
-                        this.onStart();
+                        this.onStart('drag');
 
                         cursorToElementPosition = event.getRelativeCoordinates(this.$element);
                     });
@@ -454,7 +454,7 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
                         this.gridster.onStop(this.item);
                         this.gridster.render();
                         this.isDragging = false;
-                        this.onEnd();
+                        this.onEnd('drag');
                     });
                 });
 
@@ -527,12 +527,12 @@ export class GridsterItemComponent implements OnInit, OnChanges, AfterViewInit, 
         };
     }
 
-    private onEnd(): void {
-        this.end.emit({item: this.item});
+    private onEnd(actionType: string): void {
+        this.end.emit({action: actionType, item: this.item});
     }
 
-    private onStart(): void {
-        this.start.emit({item: this.item});
+    private onStart(actionType: string): void {
+        this.start.emit({action: actionType, item: this.item});
     }
 
     /**

--- a/src/gridster.component.ts
+++ b/src/gridster.component.ts
@@ -212,7 +212,7 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
 
     private getScrollPositionFromParents(element: Element, data = {scrollTop: 0, scrollLeft: 0}): {scrollTop: number, scrollLeft: number} {
 
-        if (element.parentElement !== document.body) {
+        if (element.parentElement && element.parentElement !== document.body) {
             data.scrollTop += element.parentElement.scrollTop;
             data.scrollLeft += element.parentElement.scrollLeft;
 


### PR DESCRIPTION
angular: 5.0.1
material: 5.0.0-rc0
angular2gridster: 0.6.9

loazy load module with gridster affects:
```
SomethingComponent.html:3 ERROR TypeError: Cannot read property 'scrollTop' of null
    at GridsterComponent.getScrollPositionFromParents (gridster.component.js:132)
    at GridsterComponent.getScrollPositionFromParents (gridster.component.js:134)
    at GridsterComponent.getScrollPositionFromParents (gridster.component.js:134)
    at GridsterComponent.getScrollPositionFromParents (gridster.component.js:134)
    at GridsterComponent.updateGridsterElementData (gridster.component.js:121)
    at GridsterComponent.ngAfterContentInit (gridster.component.js:60)
    at callProviderLifecycles (core.js:12422)
    at callElementProvidersLifecycles (core.js:12399)
    at callLifecycleHooksChildrenFirst (core.js:12383)
    at checkAndUpdateView (core.js:13511)
```
same as here: https://github.com/swiety85/angular2gridster/issues/114 @speculees post