### PR TITLE
Provide tolerance for gridster config

### DIFF
--- a/demo/src/app/gridster/GridsterOptions.ts
+++ b/demo/src/app/gridster/GridsterOptions.ts
@@ -23,7 +23,8 @@ export class GridsterOptions {
         dragAndDrop: true,
         resizable: false,
         useCSSTransforms: false,
-        floating: true
+        floating: true,
+        tolerance: 'pointer'
     };
 
     change: Observable<IGridsterOptions>;

--- a/demo/src/app/gridster/IGridsterOptions.ts
+++ b/demo/src/app/gridster/IGridsterOptions.ts
@@ -15,5 +15,6 @@ export interface IGridsterOptions {
     useCSSTransforms?: boolean;
     cellHeight?: number;
     cellWidth?: number;
+    tolerance?: string;
     responsiveOptions?: Array<IGridsterOptions>;
 }

--- a/demo/src/app/gridster/gridster-prototype/gridster-item-prototype.directive.ts
+++ b/demo/src/app/gridster/gridster-prototype/gridster-item-prototype.directive.ts
@@ -143,7 +143,7 @@ export class GridsterItemPrototypeDirective implements OnInit, OnDestroy {
                     this.$element = this.provideDragElement();
                     this.containerRectange = this.$element.parentElement.getBoundingClientRect();
                     this.updateParentElementData();
-                    this.onStart();
+                    this.onStart(event);
 
                     cursorToElementPosition = event.getRelativeCoordinates(this.$element);
                 });
@@ -157,13 +157,13 @@ export class GridsterItemPrototypeDirective implements OnInit, OnDestroy {
                     y: event.clientY - cursorToElementPosition.y  - this.parentRect.top
                 });
 
-                this.onDrag();
+                this.onDrag(event);
             });
 
         const dragStopSub = draggable.dragStop
-            .subscribe(() => {
+            .subscribe((event: DraggableEvent) => {
                 this.zone.run(() => {
-                    this.onStop();
+                    this.onStop(event);
                     this.$element = null;
                 });
             });
@@ -192,23 +192,23 @@ export class GridsterItemPrototypeDirective implements OnInit, OnDestroy {
         };
     }
 
-    private onStart (): void {
+    private onStart (event: DraggableEvent): void {
         this.isDragging = true;
 
         this.$element.style.pointerEvents = 'none';
         this.$element.style.position = 'absolute';
 
-        this.gridsterPrototype.dragItemStart(this);
+        this.gridsterPrototype.dragItemStart(this, event);
 
         this.start.emit({item: this.item});
     }
 
-    private onDrag (): void {
-        this.gridsterPrototype.updatePrototypePosition(this);
+    private onDrag (event: DraggableEvent): void {
+        this.gridsterPrototype.updatePrototypePosition(this, event);
     }
 
-    private onStop (): void {
-        this.gridsterPrototype.dragItemStop(this);
+    private onStop (event: DraggableEvent): void {
+        this.gridsterPrototype.dragItemStop(this, event);
 
         this.isDragging = false;
         this.$element.style.pointerEvents = 'auto';

--- a/demo/src/app/gridster/gridster-prototype/gridster-prototype.service.ts
+++ b/demo/src/app/gridster/gridster-prototype/gridster-prototype.service.ts
@@ -94,7 +94,7 @@ export class GridsterPrototypeService {
             })
             .filter((data: any) => {
                 return !data.isDrop;
-            });
+            }).share();
 
         const dragEnter = this.createDragEnterObservable(dragExt, gridster);
         const dragOut = this.createDragOutObservable(dragExt, gridster);
@@ -208,7 +208,7 @@ export class GridsterPrototypeService {
         if (tolerance === 'touch') {
             return utils.isElementTouchContainer(el, elContainer);
         }
-
+        console.log('xoox', event.pageX, event.pageY);
         return utils.isCursorAboveElement(event, elContainer);
     }
 }

--- a/demo/src/app/gridster/gridster-prototype/gridster-prototype.service.ts
+++ b/demo/src/app/gridster/gridster-prototype/gridster-prototype.service.ts
@@ -208,7 +208,7 @@ export class GridsterPrototypeService {
         if (tolerance === 'touch') {
             return utils.isElementTouchContainer(el, elContainer);
         }
-        console.log('xoox', event.pageX, event.pageY);
+
         return utils.isCursorAboveElement(event, elContainer);
     }
 }

--- a/demo/src/app/gridster/gridster.component.ts
+++ b/demo/src/app/gridster/gridster.component.ts
@@ -237,7 +237,9 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
         const dropOverObservable = this.gridsterPrototype.observeDropOver(this.gridster)
             .publish();
 
-        this.gridsterPrototype.observeDragOver(this.gridster).dragOver
+        const dragObservable = this.gridsterPrototype.observeDragOver(this.gridster);
+
+        dragObservable.dragOver
             .subscribe((prototype: GridsterItemPrototypeDirective) => {
                 if (!isEntered) {
                     return;
@@ -245,7 +247,7 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
                 this.gridster.onDrag(prototype.item);
             });
 
-        this.gridsterPrototype.observeDragOver(this.gridster).dragEnter
+        dragObservable.dragEnter
             .subscribe((prototype: GridsterItemPrototypeDirective) => {
                 isEntered = true;
 
@@ -253,7 +255,7 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
                 this.gridster.onStart(prototype.item);
             });
 
-        this.gridsterPrototype.observeDragOver(this.gridster).dragOut
+        dragObservable.dragOut
             .subscribe((prototype: GridsterItemPrototypeDirective) => {
                 if (!isEntered) {
                     return;

--- a/demo/src/app/gridster/gridster.component.ts
+++ b/demo/src/app/gridster/gridster.component.ts
@@ -265,13 +265,13 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
             });
 
         dropOverObservable
-            .subscribe((prototype: GridsterItemPrototypeDirective) => {
+            .subscribe((data) => {
                 if (!isEntered) {
                     return;
                 }
-                this.gridster.onStop(prototype.item);
+                this.gridster.onStop(data.item.item);
 
-                this.gridster.removeItem(prototype.item);
+                this.gridster.removeItem(data.item.item);
 
                 isEntered = false;
             });

--- a/demo/src/app/gridster/utils/utils.ts
+++ b/demo/src/app/gridster/utils/utils.ts
@@ -1,14 +1,16 @@
 
+import {DraggableEvent} from './DraggableEvent';
+
 export const utils = {
-    setCssElementPosition: ($element: HTMLElement, position: {x: number, y: number}) => {
+    setCssElementPosition: function ($element: HTMLElement, position: {x: number, y: number}) {
         $element.style.left = position.x + 'px';
         $element.style.top = position.y + 'px';
     },
-    resetCSSElementPosition: ($element: HTMLElement) => {
+    resetCSSElementPosition: function ($element: HTMLElement) {
         $element.style.left = '';
         $element.style.top = '';
     },
-    setTransform: ($element: HTMLElement, position: {x: number, y: number}) => {
+    setTransform: function ($element: HTMLElement, position: {x: number, y: number}) {
         const left = position.x;
         const top = position.y;
 
@@ -21,7 +23,7 @@ export const utils = {
         $element.style['msTransform'] = translate;
         $element.style['OTransform'] = translate;
     },
-    resetTransform: ($element: HTMLElement) => {
+    resetTransform: function ($element: HTMLElement) {
         $element.style['transform'] = '';
         $element.style['WebkitTransform'] = '';
         $element.style['MozTransform'] = '';
@@ -34,5 +36,43 @@ export const utils = {
         } else if (window.getSelection) {
             window.getSelection().removeAllRanges();
         }
+    },
+    isElementFitContainer: function (element: HTMLElement, containerEl: HTMLElement): boolean {
+        const containerRect = containerEl.getBoundingClientRect();
+        const elRect = element.getBoundingClientRect();
+
+        return elRect.left > containerRect.left &&
+            elRect.right < containerRect.right &&
+            elRect.top > containerRect.top &&
+            elRect.bottom < containerRect.bottom;
+    },
+    isElementIntersectContainer: function (element: HTMLElement, containerEl: HTMLElement): boolean {
+        const containerRect = containerEl.getBoundingClientRect();
+        const elRect = element.getBoundingClientRect();
+
+        const elWidth = elRect.right - elRect.left;
+        const elHeight = elRect.bottom - elRect.top;
+
+        return (elRect.left + (elWidth / 2)) > containerRect.left &&
+            (elRect.right - (elWidth / 2)) < containerRect.right &&
+            (elRect.top + (elHeight / 2)) > containerRect.top &&
+            (elRect.bottom - (elHeight / 2)) < containerRect.bottom;
+    },
+    isElementTouchContainer: function (element: HTMLElement, containerEl: HTMLElement): boolean {
+        const containerRect = containerEl.getBoundingClientRect();
+        const elRect = element.getBoundingClientRect();
+
+        return elRect.right > containerRect.left &&
+            elRect.bottom > containerRect.top &&
+            elRect.left < containerRect.right &&
+            elRect.top < containerRect.bottom;
+    },
+    isCursorAboveElement: function (event: DraggableEvent, element): boolean {
+        const elRect = element.getBoundingClientRect();
+
+        return event.pageX > elRect.left &&
+            event.pageX < elRect.right &&
+            event.pageY > elRect.top &&
+            event.pageY < elRect.bottom;
     }
 };

--- a/src/GridsterOptions.ts
+++ b/src/GridsterOptions.ts
@@ -23,7 +23,8 @@ export class GridsterOptions {
         dragAndDrop: true,
         resizable: false,
         useCSSTransforms: false,
-        floating: true
+        floating: true,
+        tolerance: 'pointer'
     };
 
     change: Observable<IGridsterOptions>;

--- a/src/IGridsterOptions.ts
+++ b/src/IGridsterOptions.ts
@@ -15,5 +15,6 @@ export interface IGridsterOptions {
     useCSSTransforms?: boolean;
     cellHeight?: number;
     cellWidth?: number;
+    tolerance?: string;
     responsiveOptions?: Array<IGridsterOptions>;
 }

--- a/src/gridList/gridList.ts
+++ b/src/gridList/gridList.ts
@@ -417,30 +417,6 @@ export class GridList {
         return this.findDefaultPositionVertical(width, height);
     }
 
-    deleteItemPositionFromGrid(item: GridListItem) {
-        const position = this.getItemPosition(item);
-        let x, y;
-
-        for (x = position.x; x < position.x + position.w; x++) {
-            // It can happen to try to remove an item from a position not generated
-            // in the grid, probably when loading a persisted grid of items. No need
-            // to create a column to be able to remove something from it, though
-            if (!this.grid[x]) {
-                continue;
-            }
-
-            for (y = position.y; y < position.y + position.h; y++) {
-                // Don't clear the cell if it's been occupied by a different widget in
-                // the meantime (e.g. when an item has been moved over this one, and
-                // thus by continuing to clear this item's previous position you would
-                // cancel the first item's move, leaving it without any position even)
-                if (this.grid[x][y] === item) {
-                    this.grid[x][y] = null;
-                }
-            }
-        }
-    }
-
     private isItemValidForGrid(item: GridListItem, options: IGridsterOptions) {
         const itemData = options.direction === 'horizontal' ? {
             x: item.getValueY(options.breakpoint),
@@ -642,6 +618,30 @@ export class GridList {
         for (x = position.x; x < position.x + position.w; x++) {
             for (y = position.y; y < position.y + position.h; y++) {
                 this.grid[x][y] = item;
+            }
+        }
+    }
+
+    deleteItemPositionFromGrid(item: GridListItem) {
+        const position = this.getItemPosition(item);
+        let x, y;
+
+        for (x = position.x; x < position.x + position.w; x++) {
+            // It can happen to try to remove an item from a position not generated
+            // in the grid, probably when loading a persisted grid of items. No need
+            // to create a column to be able to remove something from it, though
+            if (!this.grid[x]) {
+                continue;
+            }
+
+            for (y = position.y; y < position.y + position.h; y++) {
+                // Don't clear the cell if it's been occupied by a different widget in
+                // the meantime (e.g. when an item has been moved over this one, and
+                // thus by continuing to clear this item's previous position you would
+                // cancel the first item's move, leaving it without any position even)
+                if (this.grid[x][y] === item) {
+                    this.grid[x][y] = null;
+                }
             }
         }
     }

--- a/src/gridster-prototype/gridster-item-prototype.directive.ts
+++ b/src/gridster-prototype/gridster-item-prototype.directive.ts
@@ -143,7 +143,7 @@ export class GridsterItemPrototypeDirective implements OnInit, OnDestroy {
                     this.$element = this.provideDragElement();
                     this.containerRectange = this.$element.parentElement.getBoundingClientRect();
                     this.updateParentElementData();
-                    this.onStart();
+                    this.onStart(event);
 
                     cursorToElementPosition = event.getRelativeCoordinates(this.$element);
                 });
@@ -157,13 +157,13 @@ export class GridsterItemPrototypeDirective implements OnInit, OnDestroy {
                     y: event.clientY - cursorToElementPosition.y  - this.parentRect.top
                 });
 
-                this.onDrag();
+                this.onDrag(event);
             });
 
         const dragStopSub = draggable.dragStop
-            .subscribe(() => {
+            .subscribe((event: DraggableEvent) => {
                 this.zone.run(() => {
-                    this.onStop();
+                    this.onStop(event);
                     this.$element = null;
                 });
             });
@@ -192,23 +192,23 @@ export class GridsterItemPrototypeDirective implements OnInit, OnDestroy {
         };
     }
 
-    private onStart (): void {
+    private onStart (event: DraggableEvent): void {
         this.isDragging = true;
 
         this.$element.style.pointerEvents = 'none';
         this.$element.style.position = 'absolute';
 
-        this.gridsterPrototype.dragItemStart(this);
+        this.gridsterPrototype.dragItemStart(this, event);
 
         this.start.emit({item: this.item});
     }
 
-    private onDrag (): void {
-        this.gridsterPrototype.updatePrototypePosition(this);
+    private onDrag (event: DraggableEvent): void {
+        this.gridsterPrototype.updatePrototypePosition(this, event);
     }
 
-    private onStop (): void {
-        this.gridsterPrototype.dragItemStop(this);
+    private onStop (event: DraggableEvent): void {
+        this.gridsterPrototype.dragItemStop(this, event);
 
         this.isDragging = false;
         this.$element.style.pointerEvents = 'auto';

--- a/src/gridster-prototype/gridster-prototype.service.ts
+++ b/src/gridster-prototype/gridster-prototype.service.ts
@@ -94,7 +94,7 @@ export class GridsterPrototypeService {
             })
             .filter((data: any) => {
                 return !data.isDrop;
-            });
+            }).share();
 
         const dragEnter = this.createDragEnterObservable(dragExt, gridster);
         const dragOut = this.createDragOutObservable(dragExt, gridster);
@@ -208,7 +208,7 @@ export class GridsterPrototypeService {
         if (tolerance === 'touch') {
             return utils.isElementTouchContainer(el, elContainer);
         }
-
+        console.log('xoox', event.pageX, event.pageY);
         return utils.isCursorAboveElement(event, elContainer);
     }
 }

--- a/src/gridster-prototype/gridster-prototype.service.ts
+++ b/src/gridster-prototype/gridster-prototype.service.ts
@@ -208,7 +208,7 @@ export class GridsterPrototypeService {
         if (tolerance === 'touch') {
             return utils.isElementTouchContainer(el, elContainer);
         }
-        console.log('xoox', event.pageX, event.pageY);
+
         return utils.isCursorAboveElement(event, elContainer);
     }
 }

--- a/src/gridster.component.ts
+++ b/src/gridster.component.ts
@@ -237,7 +237,9 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
         const dropOverObservable = this.gridsterPrototype.observeDropOver(this.gridster)
             .publish();
 
-        this.gridsterPrototype.observeDragOver(this.gridster).dragOver
+        const dragObservable = this.gridsterPrototype.observeDragOver(this.gridster);
+
+        dragObservable.dragOver
             .subscribe((prototype: GridsterItemPrototypeDirective) => {
                 if (!isEntered) {
                     return;
@@ -245,7 +247,7 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
                 this.gridster.onDrag(prototype.item);
             });
 
-        this.gridsterPrototype.observeDragOver(this.gridster).dragEnter
+        dragObservable.dragEnter
             .subscribe((prototype: GridsterItemPrototypeDirective) => {
                 isEntered = true;
 
@@ -253,7 +255,7 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
                 this.gridster.onStart(prototype.item);
             });
 
-        this.gridsterPrototype.observeDragOver(this.gridster).dragOut
+        dragObservable.dragOut
             .subscribe((prototype: GridsterItemPrototypeDirective) => {
                 if (!isEntered) {
                     return;

--- a/src/gridster.component.ts
+++ b/src/gridster.component.ts
@@ -265,13 +265,13 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
             });
 
         dropOverObservable
-            .subscribe((prototype: GridsterItemPrototypeDirective) => {
+            .subscribe((data) => {
                 if (!isEntered) {
                     return;
                 }
-                this.gridster.onStop(prototype.item);
+                this.gridster.onStop(data.item.item);
 
-                this.gridster.removeItem(prototype.item);
+                this.gridster.removeItem(data.item.item);
 
                 isEntered = false;
             });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,14 +1,16 @@
 
+import {DraggableEvent} from './DraggableEvent';
+
 export const utils = {
-    setCssElementPosition: ($element: HTMLElement, position: {x: number, y: number}) => {
+    setCssElementPosition: function ($element: HTMLElement, position: {x: number, y: number}) {
         $element.style.left = position.x + 'px';
         $element.style.top = position.y + 'px';
     },
-    resetCSSElementPosition: ($element: HTMLElement) => {
+    resetCSSElementPosition: function ($element: HTMLElement) {
         $element.style.left = '';
         $element.style.top = '';
     },
-    setTransform: ($element: HTMLElement, position: {x: number, y: number}) => {
+    setTransform: function ($element: HTMLElement, position: {x: number, y: number}) {
         const left = position.x;
         const top = position.y;
 
@@ -21,7 +23,7 @@ export const utils = {
         $element.style['msTransform'] = translate;
         $element.style['OTransform'] = translate;
     },
-    resetTransform: ($element: HTMLElement) => {
+    resetTransform: function ($element: HTMLElement) {
         $element.style['transform'] = '';
         $element.style['WebkitTransform'] = '';
         $element.style['MozTransform'] = '';
@@ -34,5 +36,43 @@ export const utils = {
         } else if (window.getSelection) {
             window.getSelection().removeAllRanges();
         }
+    },
+    isElementFitContainer: function (element: HTMLElement, containerEl: HTMLElement): boolean {
+        const containerRect = containerEl.getBoundingClientRect();
+        const elRect = element.getBoundingClientRect();
+
+        return elRect.left > containerRect.left &&
+            elRect.right < containerRect.right &&
+            elRect.top > containerRect.top &&
+            elRect.bottom < containerRect.bottom;
+    },
+    isElementIntersectContainer: function (element: HTMLElement, containerEl: HTMLElement): boolean {
+        const containerRect = containerEl.getBoundingClientRect();
+        const elRect = element.getBoundingClientRect();
+
+        const elWidth = elRect.right - elRect.left;
+        const elHeight = elRect.bottom - elRect.top;
+
+        return (elRect.left + (elWidth / 2)) > containerRect.left &&
+            (elRect.right - (elWidth / 2)) < containerRect.right &&
+            (elRect.top + (elHeight / 2)) > containerRect.top &&
+            (elRect.bottom - (elHeight / 2)) < containerRect.bottom;
+    },
+    isElementTouchContainer: function (element: HTMLElement, containerEl: HTMLElement): boolean {
+        const containerRect = containerEl.getBoundingClientRect();
+        const elRect = element.getBoundingClientRect();
+
+        return elRect.right > containerRect.left &&
+            elRect.bottom > containerRect.top &&
+            elRect.left < containerRect.right &&
+            elRect.top < containerRect.bottom;
+    },
+    isCursorAboveElement: function (event: DraggableEvent, element): boolean {
+        const elRect = element.getBoundingClientRect();
+
+        return event.pageX > elRect.left &&
+            event.pageX < elRect.right &&
+            event.pageY > elRect.top &&
+            event.pageY < elRect.bottom;
     }
 };


### PR DESCRIPTION
Specifies which mode to use for testing whether a item prototype is
hovering over a gridster. Possible values: pointer (default), fit,
intersect, touch.
Can solve #71 