### PR TITLE
Add new option `gristerOptions.lines.backgroundColor`

### DIFF
--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -44,6 +44,7 @@ export class AppComponent {
         lines: {
           visible: true,
           color: '#afafaf',
+          backgroundColor: 'rgba(0, 0, 0, 0.15)',
           width: 2
         },
         shrink: true,

--- a/src/IGridsterOptions.ts
+++ b/src/IGridsterOptions.ts
@@ -23,6 +23,7 @@ export interface IGridsterOptions {
     lines?: {
         visible?: boolean,
         color?: string,
+        backgroundColor?: string;
         width?: number
     };
     breakpoint?: string;

--- a/src/gridster.service.ts
+++ b/src/gridster.service.ts
@@ -392,14 +392,15 @@ export class GridsterService {
         if (this.options.lines && this.options.lines.visible &&
             (this.gridsterComponent.isDragging || this.gridsterComponent.isResizing)) {
             const linesColor = this.options.lines.color || '#d8d8d8';
+            const linesBgColor = this.options.lines.backgroundColor || 'transparent';
             const linesWidth = this.options.lines.width || 1;
             const bgPosition = linesWidth / 2;
 
             gridsterContainer.style.backgroundSize = `${this.cellWidth}px ${this.cellHeight}px`;
             gridsterContainer.style.backgroundPosition = `-${bgPosition}px -${bgPosition}px`;
             gridsterContainer.style.backgroundImage = `
-                linear-gradient(to right, ${linesColor} ${linesWidth}px, transparent ${linesWidth}px),
-                linear-gradient(to bottom, ${linesColor} ${linesWidth}px, transparent ${linesWidth}px)
+                linear-gradient(to right, ${linesColor} ${linesWidth}px, ${linesBgColor} ${linesWidth}px),
+                linear-gradient(to bottom, ${linesColor} ${linesWidth}px, ${linesBgColor} ${linesWidth}px)
             `;
         } else {
             gridsterContainer.style.backgroundSize = '';


### PR DESCRIPTION
Add new option `gristerOptions.lines.backgroundColor` to enable setting background color of grid lines. This allows easily changing the backgroundColor of the grid from the gristerOptions object.