### PR TITLE
fix getHProperty function

### DIFF
--- a/projects/angular2gridster/src/lib/gridList/GridListItem.ts
+++ b/projects/angular2gridster/src/lib/gridList/GridListItem.ts
@@ -350,7 +350,7 @@ export class GridListItem {
     private getHProperty(breakpoint?: string) {
         if (this.itemPrototype) {
             return this.itemPrototype[GridListItem.H_PROPERTY_MAP[breakpoint]] ?
-                GridListItem.H_PROPERTY_MAP[breakpoint] : 'w';
+                GridListItem.H_PROPERTY_MAP[breakpoint] : 'h';
         }
 
         const item = this.getItem();


### PR DESCRIPTION
fix getHProperty function causing item prototype size always follows the width size and ignoring the height size.