### PR TITLE
Unpinned the Angular version at 13.1.1

### DIFF
--- a/projects/angular2gridster/package.json
+++ b/projects/angular2gridster/package.json
@@ -1,8 +1,8 @@
 {
     "name": "angular2gridster",
     "peerDependencies": {
-        "@angular/common": "13.1.1",
-        "@angular/core": "13.1.1"
+        "@angular/common": "^13.1.1",
+        "@angular/core": "^13.1.1"
     },
     "dependencies": {
         "tslib": "^2.3.1"


### PR DESCRIPTION
The version for Angular is currently locked to 13.1.1.  This patch allows higher versions of Angular to work without needing to use the `--force` flag while installing.