### PR TITLE
Fix for resizing south when the scrollable container is the body.

### DIFF
--- a/projects/angular2gridster/src/lib/gridster.component.ts
+++ b/projects/angular2gridster/src/lib/gridster.component.ts
@@ -294,7 +294,7 @@ export class GridsterComponent implements OnInit, AfterContentInit, OnDestroy {
         element: Element,
         data = { scrollTop: 0, scrollLeft: 0 }
     ): { scrollTop: number; scrollLeft: number } {
-        if (element.parentElement && element.parentElement !== document.body) {
+        if (element.parentElement) {
             data.scrollTop += element.parentElement.scrollTop;
             data.scrollLeft += element.parentElement.scrollLeft;
 


### PR DESCRIPTION
Allows the gridster component to calculate its scroll position from the `<body>` element.

Fixes #416 